### PR TITLE
MUS-6988 murine os fix nvidia container version

### DIFF
--- a/Containerfile.image.l4t32
+++ b/Containerfile.image.l4t32
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 LABEL org.opencontainers.image.authors="Badr @pythops"
 
 # Define the BSP version
-ARG BSP=https://developer.download.nvidia.com/embedded/L4T/r32_Release_v7.4/T210/Jetson-210_Linux_R32.7.4_aarch64.tbz2
+ARG BSP=https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T210/Tegra210_Linux_R32.5.0_aarch64.tbz2
 
 # Install different dependencies
 RUN apt update && \

--- a/Containerfile.image.l4t32
+++ b/Containerfile.image.l4t32
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 LABEL org.opencontainers.image.authors="Badr @pythops"
 
 # Define the BSP version
-ARG BSP=https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T210/Tegra210_Linux_R32.5.0_aarch64.tbz2
+ARG BSP=https://developer.nvidia.com/embedded/l4t/r32_release_v5.1/r32_release_v5.1/t210/jetson-210_linux_r32.5.1_aarch64.tbz2
 
 # Install different dependencies
 RUN apt update && \


### PR DESCRIPTION
Summary:
Fixes an issue where dax_video failed to run when building a new image from scratch due to an incompatibility between the base BSP version and the installed nvidia-container-runtime.

Details:
When using Jetson-210_Linux_R32.7.4_aarch64.tbz2 as the BSP, the container would crash during initialization with the following error:

`nvidia-container-cli: initialization error: driver error: failed to process request`

This was caused by a mismatch between the nvidia-container-runtime version installed on the host (v3.1.0-1) and the newer libraries included in the R32.7.4 BSP. The Jetson host is currently running JetPack 4.6.1 (R32.5.1), so using a newer BSP inside the container caused runtime failures.

Fix:
Switched the BSP to match the installed JetPack version on the host:

```
ARG BSP=https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T210/Tegra210_Linux_R32.5.0_aarch64.tbz2
This ensures compatibility between the container and host runtime environment.

```
Result:
dax_video now starts correctly when building the image from scratch.
Ran MFG tests to capture images 